### PR TITLE
Read ENV variables before loading the decryptor

### DIFF
--- a/src/decryptors/nodejs4.3/_serverless_handler.js
+++ b/src/decryptors/nodejs4.3/_serverless_handler.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var decryptor = require('./serverless-secrets/decryptor');
-
 var envVars = __ENV_VARS__;
 for (var key in envVars) {
   process.env[key] = envVars[key];
 }
+
+var decryptor = require('./serverless-secrets/decryptor');
 
 module.exports.handler = function(event, context, callback) {
   decryptor(function(){


### PR DESCRIPTION
Otherwise the decryptor doesn't have the required variables at load time.... like region...
See https://github.com/trek10inc/serverless-secrets/issues/8