### PR TITLE
Fix getParameters() limit of 10 parameters

### DIFF
--- a/lib/providers/aws.js
+++ b/lib/providers/aws.js
@@ -12,16 +12,30 @@ module.exports = function (options) {
 
   function getSecret (parameterNames) {
     const names = Array.isArray(parameterNames) ? parameterNames : [parameterNames]
-    const params = {
-      Names: names,
-      WithDecryption: true
-    }
+    
+    return new Promise((resolve) => {
+      let secretPromises = [];
 
-    return ssm.getParameters(params).promise().then(data => {
-      return data.Parameters.reduce((obj, x) => {
-        obj[x.Name] = x.Value
-        return obj
-      }, {})
+      for (let index = 0; index < names.length; index += 10) {
+        const params = {
+          Names: names.slice(index, index + 10),
+          WithDecryption: true
+        }
+    
+        secretPromises.push(ssm.getParameters(params).promise());
+      }
+
+      let secrets = {};
+      
+      Promise.all(secretPromises).then(results => {
+        for (const result of results) {
+          for (const parameter of result.Parameters) {
+            secrets[parameter.Name] = parameter.Value
+          }
+        }
+
+        resolve(secrets)
+      })
     })
   }
 


### PR DESCRIPTION
Hey there! 👋

So, [`getParameters()`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameters.html) has a limit of getting a maximum of 10 parameters only. 😭

It results in the following error if the number of parameters is more than 10:

```
UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1):
ValidationException: 1 validation error detected: Value '[omitted-parameter-names]' at 'names'
failed to satisfy constraint: Member must have length less than or equal to 10
```

This PR fixes this by calling `getParameters()` multiple times depending on the total number of parameters. 🎉