### PR TITLE
Automatically set region

### DIFF
--- a/lib/providers/aws.js
+++ b/lib/providers/aws.js
@@ -3,8 +3,7 @@
 const AWS = require('aws-sdk')
 
 const defaultOptions = {
-  apiVersion: '2014-11-06',
-  region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
+  apiVersion: '2014-11-06'
 }
 
 module.exports = function (options) {


### PR DESCRIPTION
If not set it automatically uses the environment variable or defaults set via the serverless region setting.