### PR TITLE
Save serverless-secrets as normal dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ to load the secrets.
 
 In the root of your Serverless project:
 
-`npm install serverless-secrets --save-dev` or `yarn add serverless-secrets --dev`
+`npm install serverless-secrets --save` or `yarn add serverless-secrets`
 
 Add the plugin to your `serverless.yml`:
 


### PR DESCRIPTION
Need to save as a regular dependency, otherwise the `require('serverless-secrets/client')` will fail.