### PR TITLE
Option to disable plugin in serverless.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ is unable to be retrieved. Default value: `true`.
 The following options apply only to the custom section as they are only used in deploy/package CLI
 operations:
 
+- `enabled` - boolean: If set to false, the plugin is disabled. This is useful for local development.
+Default value: `true`.
 - `skipValidation` - boolean: If set to true, validation of the existence of your secrets in
 your provider's secret store will not be performed during deployment/packaging operations.
 Default value: `false`.

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -110,16 +110,21 @@ class ServerlessSecrets {
       'secrets:delete:delete': this.deleteSecret.bind(this),
       'secrets:list-remote:list-remote': this.listRemoteSecretNames.bind(this),
       'secrets:validate:validate': this.validateSecrets.bind(this),
-      'before:package:setupProviderConfiguration': this.setIamPermissions.bind(this),
-      'before:package:createDeploymentArtifacts': this.packageSecrets.bind(this),
-      'after:package:createDeploymentArtifacts': this.cleanupPackageSecrets.bind(this),
-      'before:deploy:function:packageFunction': this.packageSecrets.bind(this),
-      'after:deploy:function:packageFunction': this.cleanupPackageSecrets.bind(this),
-      'before:offline:start': this.packageSecrets.bind(this),
-      'before:offline:start:init': this.packageSecrets.bind(this),
-      'before:offline:start:end': this.cleanupPackageSecrets.bind(this),
-      'before:invoke:local:invoke': this.packageSecrets.bind(this),
-      'after:invoke:local:invoke': this.cleanupPackageSecrets.bind(this)
+    };
+
+    if (options.enabled) {
+      this.hooks = Object.assign(this.hooks, {
+        'before:package:setupProviderConfiguration': this.setIamPermissions.bind(this),
+        'before:package:createDeploymentArtifacts': this.packageSecrets.bind(this),
+        'after:package:createDeploymentArtifacts': this.cleanupPackageSecrets.bind(this),
+        'before:deploy:function:packageFunction': this.packageSecrets.bind(this),
+        'after:deploy:function:packageFunction': this.cleanupPackageSecrets.bind(this),
+        'before:offline:start': this.packageSecrets.bind(this),
+        'before:offline:start:init': this.packageSecrets.bind(this),
+        'before:offline:start:end': this.cleanupPackageSecrets.bind(this),
+        'before:invoke:local:invoke': this.packageSecrets.bind(this),
+        'after:invoke:local:invoke': this.cleanupPackageSecrets.bind(this)
+      });
     }
   }
 


### PR DESCRIPTION
This makes it possible to disable the plugin in the `serverless.yml`. The default behaviour should be unchanged.